### PR TITLE
Bugfix - incorrect sprite sorting of subcomponents when dragging

### DIFF
--- a/Merge Conflict/Assets/Scripts/ComponentSpawner.cs
+++ b/Merge Conflict/Assets/Scripts/ComponentSpawner.cs
@@ -83,7 +83,7 @@ public class ComponentSpawner : MonoBehaviour
     {
         GameObject slotComponentObject = Instantiate(new GameObject(""));
         slotComponentObject.name = $"{element.GetType()}_child";
-        slotComponentObject.tag = Tags.Untagged.ToString();
+        slotComponentObject.tag = Tags.SubComponent.ToString();
         slotComponentObject.transform.position = spawnPosition;
         slotComponentObject.transform.SetParent(parentComponentObject.transform, true);
         slotComponentObject.AddComponent<SpriteRenderer>();

--- a/Merge Conflict/Assets/Scripts/Components/ElementTexture.cs
+++ b/Merge Conflict/Assets/Scripts/Components/ElementTexture.cs
@@ -23,6 +23,11 @@ public class ElementTexture : ScriptableObject
 
     public GameObject ApplyTexture(GameObject gameObject)
     {
+        if (gameObject.TryGetComponent(out RectTransform _) == false || gameObject.TryGetComponent(out SpriteRenderer _) == false)
+        {
+            Debugger.LogError("ApplyTexture: gameObject does not have RectTransform or SpriteRenderer attached!!!");
+        }
+
         gameObject.GetComponent<SpriteRenderer>().sprite = elementSprite;
         gameObject.GetComponent<SpriteRenderer>().color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
         gameObject.GetComponent<RectTransform>().sizeDelta = new Vector2(sizeWidth, sizeHeight);

--- a/Merge Conflict/Assets/Scripts/Tags.cs
+++ b/Merge Conflict/Assets/Scripts/Tags.cs
@@ -15,6 +15,7 @@ public enum Tags
 {
     Untagged,
     Component,
+    SubComponent,
     Trashcan,
     ConveyorBelt,
     ConveyorBeltDiagonal

--- a/Merge Conflict/Assets/Scripts/TextureAtlas.cs
+++ b/Merge Conflict/Assets/Scripts/TextureAtlas.cs
@@ -4,7 +4,7 @@ Description:   Elements data structure for texture.
 
 Author(s):     Daniel Rittrich
 Date:          2024-02-27
-Version:       V2.1 
+Version:       V2.2 
 TODO:          - /
 **********************************************************************************************************************/
 
@@ -58,7 +58,7 @@ public class TextureAtlas : MonoBehaviour
             new float[] { 4f, 4f, scale },
             new float[] { 3f, 3.5f, scale },
             new float[] { 3f, 4f, scale }
-        }; // banana, bug, can
+        }; // { {banana}, {bug}, {can} }
 
     public ElementTexture defaultTexture;
     public static float[] defaultTextureValues = { 5f, 5f, scale };

--- a/Merge Conflict/ProjectSettings/TagManager.asset
+++ b/Merge Conflict/ProjectSettings/TagManager.asset
@@ -9,6 +9,7 @@ TagManager:
   - ConveyorBeltDiagonal
   - Component
   - Trashcan
+  - SubComponent
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Bugfixed the sprite sorting of child gameObjects when dragging